### PR TITLE
Added read instance to TimeStamp for UTC+Timezone

### DIFF
--- a/lib/Vaultaire/Types/TimeStamp.hs
+++ b/lib/Vaultaire/Types/TimeStamp.hs
@@ -77,6 +77,7 @@ instance Read TimeStamp where
         parse x =   parseTime defaultTimeLocale "%FT%T%QZ" x
                 <|> parseTime defaultTimeLocale "%F" x
                 <|> parseTime defaultTimeLocale "%s%Q" x
+                <|> parseTime defaultTimeLocale "%FT%T%Q%z" x
 
 instance WireFormat TimeStamp where
     toWire = runPacking 8 . putWord64LE . unTimeStamp

--- a/vaultaire-common.cabal
+++ b/vaultaire-common.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >= 1.10
 name:                vaultaire-common
-version:             2.5.1
+version:             2.5.2
 synopsis:            Common types and instances for Vaultaire
 license:             BSD3
 author:              Anchor Engineering <engineering@anchor.com.au>


### PR DESCRIPTION
Legacy API uses this format, convenient for resource mapping 
