### PR TITLE
Add decoded simple/ext points

### DIFF
--- a/lib/Vaultaire/Types.hs
+++ b/lib/Vaultaire/Types.hs
@@ -56,6 +56,10 @@ module Vaultaire.Types
     SimpleBurst(..),
     ExtendedBurst(..),
 
+    -- * Decoded reads
+    SimplePoint(..),
+    ExtendedPoint(..),
+
     -- * Writes
     WriteResult(..),
 
@@ -84,6 +88,7 @@ import Vaultaire.Types.ContentsListBypass
 import Vaultaire.Types.ContentsOperation
 import Vaultaire.Types.ContentsResponse
 import Vaultaire.Types.DayMap
+import Vaultaire.Types.Decoded
 import Vaultaire.Types.PassThrough
 import Vaultaire.Types.ReadRequest
 import Vaultaire.Types.ReadStream

--- a/lib/Vaultaire/Types/Decoded.hs
+++ b/lib/Vaultaire/Types/Decoded.hs
@@ -1,0 +1,33 @@
+module Vaultaire.Types.Decoded
+  ( SimplePoint(..)
+  , ExtendedPoint(..)
+  ) where
+
+import Data.Word (Word64)
+import Data.ByteString (ByteString)
+import Vaultaire.Types.Address
+import Vaultaire.Types.TimeStamp
+
+-- | SimplePoints are simply wrapped packets for Vaultaire
+-- Each consists of 24 bytes:
+-- An 8 byte Address
+-- An 8 byte Timestamp (nanoseconds since Unix epoch)
+-- An 8 byte Payload
+data SimplePoint = SimplePoint { simpleAddress :: Address
+                               , simpleTime    :: TimeStamp
+                               , simplePayload :: Word64 }
+  deriving (Show, Eq)
+
+
+-- | ExtendedPoints are simply wrapped packets for Vaultaire
+-- Each consists of 16 + 'length' bytes:
+-- An 8 byte Address
+-- An 8 byte Time (in nanoseconds since Unix epoch)
+-- A 'length' byte Payload
+-- On the wire their equivalent representation takes up
+-- 24 + 'length' bytes with format:
+-- 8 byte Address, 8 byte Time, 8 byte Length, Payload
+data ExtendedPoint = ExtendedPoint { extendedAddress :: Address
+                                   , extendedTime    :: TimeStamp
+                                   , extendedPayload :: ByteString }
+  deriving (Show, Eq)

--- a/lib/Vaultaire/Types/Decoded.hs
+++ b/lib/Vaultaire/Types/Decoded.hs
@@ -13,9 +13,9 @@ import Vaultaire.Types.TimeStamp
 -- An 8 byte Address
 -- An 8 byte Timestamp (nanoseconds since Unix epoch)
 -- An 8 byte Payload
-data SimplePoint = SimplePoint { simpleAddress :: Address
-                               , simpleTime    :: TimeStamp
-                               , simplePayload :: Word64 }
+data SimplePoint = SimplePoint { simpleAddress :: {-# UNPACK #-} !Address
+                               , simpleTime    :: {-# UNPACK #-} !TimeStamp
+                               , simplePayload :: {-# UNPACK #-} !Word64 }
   deriving (Show, Eq)
 
 

--- a/vaultaire-common.cabal
+++ b/vaultaire-common.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >= 1.10
 name:                vaultaire-common
-version:             2.8.2
+version:             2.8.3
 synopsis:            Common types and instances for Vaultaire
 description:         Defines a set of types, typeclasses and instances for
                      Vaultaire, intended for use with Marquise and other


### PR DESCRIPTION
Move Simple/Extended Point defs from Marquise to here so we avoid incurring a dep on zmq if we only want the types.

Marquise still exports those types so nothing should break.

@fractalcat 