### PR TITLE
Introduced UOM Type for Telemetry Messages

### DIFF
--- a/lib/Vaultaire/Types/Telemetry.hs
+++ b/lib/Vaultaire/Types/Telemetry.hs
@@ -72,7 +72,7 @@ data TeleMsgUOM
 instance Show TeleMsgUOM where
   show Points       = "points"
   show Requests     = "requests"
-  show Microseconds = "ms"
+  show Microseconds = "μs"
 
 msgTypeUOM :: TeleMsgType -> TeleMsgUOM
 msgTypeUOM WriterSimplePoints       = Points

--- a/lib/Vaultaire/Types/Telemetry.hs
+++ b/lib/Vaultaire/Types/Telemetry.hs
@@ -3,6 +3,8 @@ module Vaultaire.Types.Telemetry
      ( TeleResp(..)
      , TeleMsg(..)
      , TeleMsgType(..)
+     , TeleMsgUOM(..)
+     , msgTypeUOM
      , AgentID, agentID )
 where
 
@@ -61,6 +63,34 @@ data TeleMsgType
    | ContentsUpdateCeph       -- ^ Mean Ceph latency for one update request
    deriving (Enum, Bounded, Eq, Ord)
 
+data TeleMsgUOM
+    = Points
+    | Requests
+    | Microseconds
+    deriving (Enum, Bounded, Eq, Ord)
+
+instance Show TeleMsgUOM where
+  show Points       = "points"
+  show Requests     = "requests"
+  show Microseconds = "ms"
+
+msgTypeUOM :: TeleMsgType -> TeleMsgUOM
+msgTypeUOM WriterSimplePoints       = Points
+msgTypeUOM WriterExtendedPoints     = Points
+msgTypeUOM WriterRequest            = Requests
+msgTypeUOM WriterRequestLatency     = Microseconds
+msgTypeUOM WriterCephLatency        = Microseconds
+msgTypeUOM ReaderSimplePoints       = Points
+msgTypeUOM ReaderExtendedPoints     = Points
+msgTypeUOM ReaderRequest            = Requests
+msgTypeUOM ReaderRequestLatency     = Microseconds
+msgTypeUOM ReaderCephLatency        = Microseconds
+msgTypeUOM ContentsEnumerate        = Requests
+msgTypeUOM ContentsUpdate           = Requests
+msgTypeUOM ContentsEnumerateLatency = Microseconds
+msgTypeUOM ContentsUpdateLatency    = Microseconds
+msgTypeUOM ContentsEnumerateCeph    = Microseconds
+msgTypeUOM ContentsUpdateCeph       = Microseconds
 
 chomp :: ByteString -> ByteString
 chomp = S.takeWhile (/='\0')
@@ -171,20 +201,4 @@ instance Show TeleMsg where
                   , let s = show (fromIntegral $ _payload m :: Int)
                     in  replicate (8 - length s) ' ' ++ s
                   , " "
-                  , showUnit $ _type m ]
-    where showUnit WriterSimplePoints       = "points"
-          showUnit WriterExtendedPoints     = "points"
-          showUnit WriterRequest            = "requests"
-          showUnit WriterRequestLatency     = "ms"
-          showUnit WriterCephLatency        = "ms"
-          showUnit ReaderSimplePoints       = "points"
-          showUnit ReaderExtendedPoints     = "points"
-          showUnit ReaderRequest            = "requests"
-          showUnit ReaderRequestLatency     = "ms"
-          showUnit ReaderCephLatency        = "ms"
-          showUnit ContentsEnumerate        = "requests"
-          showUnit ContentsUpdate           = "requests"
-          showUnit ContentsEnumerateLatency = "ms"
-          showUnit ContentsUpdateLatency    = "ms"
-          showUnit ContentsEnumerateCeph    = "ms"
-          showUnit ContentsUpdateCeph       = "ms"
+                  , show $ msgTypeUOM $ _type m ]

--- a/lib/Vaultaire/Types/Telemetry.hs
+++ b/lib/Vaultaire/Types/Telemetry.hs
@@ -43,7 +43,7 @@ data TeleMsg = TeleMsg
      , _payload :: Word64
      } deriving Eq
 
--- | Telemetry types. All counts are absolute and all latencies are in microseconds.
+-- | Telemetry types. All counts are absolute and all latencies are in milliseconds.
 data TeleMsgType
    = WriterSimplePoints       -- ^ Total number of simple points written since last message
    | WriterExtendedPoints     -- ^ Total number of extended points written since last message
@@ -66,31 +66,31 @@ data TeleMsgType
 data TeleMsgUOM
     = Points
     | Requests
-    | Microseconds
+    | Milliseconds
     deriving (Enum, Bounded, Eq, Ord)
 
 instance Show TeleMsgUOM where
   show Points       = "points"
   show Requests     = "requests"
-  show Microseconds = "μs"
+  show Milliseconds = "ms"
 
 msgTypeUOM :: TeleMsgType -> TeleMsgUOM
 msgTypeUOM WriterSimplePoints       = Points
 msgTypeUOM WriterExtendedPoints     = Points
 msgTypeUOM WriterRequest            = Requests
-msgTypeUOM WriterRequestLatency     = Microseconds
-msgTypeUOM WriterCephLatency        = Microseconds
+msgTypeUOM WriterRequestLatency     = Milliseconds
+msgTypeUOM WriterCephLatency        = Milliseconds
 msgTypeUOM ReaderSimplePoints       = Points
 msgTypeUOM ReaderExtendedPoints     = Points
 msgTypeUOM ReaderRequest            = Requests
-msgTypeUOM ReaderRequestLatency     = Microseconds
-msgTypeUOM ReaderCephLatency        = Microseconds
+msgTypeUOM ReaderRequestLatency     = Milliseconds
+msgTypeUOM ReaderCephLatency        = Milliseconds
 msgTypeUOM ContentsEnumerate        = Requests
 msgTypeUOM ContentsUpdate           = Requests
-msgTypeUOM ContentsEnumerateLatency = Microseconds
-msgTypeUOM ContentsUpdateLatency    = Microseconds
-msgTypeUOM ContentsEnumerateCeph    = Microseconds
-msgTypeUOM ContentsUpdateCeph       = Microseconds
+msgTypeUOM ContentsEnumerateLatency = Milliseconds
+msgTypeUOM ContentsUpdateLatency    = Milliseconds
+msgTypeUOM ContentsEnumerateCeph    = Milliseconds
+msgTypeUOM ContentsUpdateCeph       = Milliseconds
 
 chomp :: ByteString -> ByteString
 chomp = S.takeWhile (/='\0')

--- a/vaultaire-common.cabal
+++ b/vaultaire-common.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >= 1.10
 name:                vaultaire-common
-version:             2.8.3
+version:             2.8.4
 synopsis:            Common types and instances for Vaultaire
 description:         Defines a set of types, typeclasses and instances for
                      Vaultaire, intended for use with Marquise and other


### PR DESCRIPTION
separated telemetry UOMs into a type for more convenient manipulation and collection. Primarily to help produce more meaningful SourceDicts in vaultaire-collector-vaultaire-telemetry