### PR TITLE
Agent id length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 2.9.0
+
+# Interface
+
+ - Expose telemetry message UOM type TeleMsgUOM, and message-type -> UOM
+   mapping function msgTypeUOM.
+ - Add a constant agentIDLength used to validate telemetry messages, and
+   export it so clients can construct valid IDs.
+
 # 2.8.0
 
 ## Interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# 2.8.0
+
+## Interface
+
+Added telemetric data types for profiling Vaultaire.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,0 @@
-= 2.8.0
-
-Added telemetric data types for profling Vaultaire.

--- a/lib/Vaultaire/Types.hs
+++ b/lib/Vaultaire/Types.hs
@@ -76,7 +76,7 @@ module Vaultaire.Types
     TeleMsgType(..),
     TeleMsgUOM(..),
     msgTypeUOM,
-    AgentID, agentID,
+    AgentID, agentIDLength, agentID,
 
     -- * Convenience/clarity
     Epoch,

--- a/lib/Vaultaire/Types/Telemetry.hs
+++ b/lib/Vaultaire/Types/Telemetry.hs
@@ -110,10 +110,10 @@ agentID s | length s <= agentIDLength && notElem '\0' s
 
 putAgentID :: AgentID -> Packing ()
 putAgentID (AgentID x)
-  = putBytes $ S.pack $ x ++ replicate (64 - length x) '\0'
+  = putBytes $ S.pack $ x ++ replicate (agentIDLength - length x) '\0'
 
 getAgentID :: Unpacking AgentID
-getAgentID = AgentID . S.unpack . chomp <$> getBytes 64
+getAgentID = AgentID . S.unpack . chomp <$> getBytes agentIDLength
 
 -- | Pack a telemetry message. Assumes the origin is no longer than
 --   eight bytes.
@@ -135,7 +135,7 @@ getTeleMsg = do
     return $ fmap (\org -> TeleMsg org t p) o
 
 instance WireFormat AgentID where
-  toWire   = runPacking 64 . putAgentID
+  toWire   = runPacking agentIDLength . putAgentID
   fromWire = tryUnpacking    getAgentID
 
 instance WireFormat TeleMsg where

--- a/lib/Vaultaire/Types/Telemetry.hs
+++ b/lib/Vaultaire/Types/Telemetry.hs
@@ -22,8 +22,8 @@ import Vaultaire.Classes.WireFormat
 import Vaultaire.Types.Common
 import Vaultaire.Types.TimeStamp
 
-
-
+-- | ID string associated with a running daemon, so telemetry messages
+--   can be associated with the processes which sent them.
 newtype AgentID = AgentID String
         deriving (Eq, Ord, Monoid)
 
@@ -74,6 +74,7 @@ instance Show TeleMsgUOM where
   show Requests     = "requests"
   show Milliseconds = "ms"
 
+-- | Map a telemetry message type onto its associated UOM.
 msgTypeUOM :: TeleMsgType -> TeleMsgUOM
 msgTypeUOM WriterSimplePoints       = Points
 msgTypeUOM WriterExtendedPoints     = Points
@@ -92,6 +93,8 @@ msgTypeUOM ContentsUpdateLatency    = Milliseconds
 msgTypeUOM ContentsEnumerateCeph    = Milliseconds
 msgTypeUOM ContentsUpdateCeph       = Milliseconds
 
+-- | Return (possibly empty) prefix component of a ByteString terminated
+--   by one or more null bytes.
 chomp :: ByteString -> ByteString
 chomp = S.takeWhile (/='\0')
 
@@ -112,6 +115,8 @@ putAgentID (AgentID x)
 getAgentID :: Unpacking AgentID
 getAgentID = AgentID . S.unpack . chomp <$> getBytes 64
 
+-- | Pack a telemetry message. Assumes the origin is no longer than
+--   eight bytes.
 putTeleMsg :: TeleMsg -> Packing ()
 putTeleMsg x = do
     -- 8 bytes for the origin.

--- a/lib/Vaultaire/Types/Telemetry.hs
+++ b/lib/Vaultaire/Types/Telemetry.hs
@@ -5,7 +5,7 @@ module Vaultaire.Types.Telemetry
      , TeleMsgType(..)
      , TeleMsgUOM(..)
      , msgTypeUOM
-     , AgentID, agentID )
+     , AgentID, agentIDLength, agentID )
 where
 
 import Control.Applicative
@@ -95,9 +95,13 @@ msgTypeUOM ContentsUpdateCeph       = Milliseconds
 chomp :: ByteString -> ByteString
 chomp = S.takeWhile (/='\0')
 
+-- | Agent IDs are a maximum of 64 bytes.
+agentIDLength :: Int
+agentIDLength = 64
+
 -- | An agent ID has to fit in 64 characters and does not contain \NUL.
 agentID :: String -> Maybe AgentID
-agentID s | length s <= 64 && notElem '\0' s
+agentID s | length s <= agentIDLength && notElem '\0' s
           = Just $ AgentID s
           | otherwise = Nothing
 


### PR DESCRIPTION
An exposed AgentIDLength allows clients to construct agent IDs which
fit within the message field while retaining their meaning - e.g., if a
client uses an agent ID of the form `hostname <> "-" <> pid` to ensure
uniqueness, they can truncate the hostname at (agentIDLength -
length-of-pid) bytes.

Also, some missing documentation and changelog update for this and the previous interface change.